### PR TITLE
Using ES5 syntax in storybook webpack config as ES6 is incompatible

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,5 +1,5 @@
 require('babel-register');
-let mainWebpackConfig = require('../build/webpack.config.js').default;
+var mainWebpackConfig = require('../build/webpack.config.js').default;
 
 module.exports = (storybookBaseConfig, configType) => {
   storybookBaseConfig.module.loaders = mainWebpackConfig.module.loaders;


### PR DESCRIPTION
This pull request addresses issue #32 
