### PR TITLE
Extract Bootstrap styles in prod builds to ensure correct CSS load order

### DIFF
--- a/.bootstraprc
+++ b/.bootstraprc
@@ -18,14 +18,15 @@ styleLoaders:
 # Extract styles to stand-alone css file
 # Different settings for different environments can be used,
 # It depends on value of NODE_ENV environment variable
-# This param can also be set in webpack config:
+#
+# This param can also be set in webpack config: <-- HAS now been set there.
 #   entry: 'bootstrap-loader/extractStyles'
-extractStyles: false
-env:
-  development:
-    extractStyles: false
-  production:
-    extractStyles: true
+#  extractStyles: false
+#  env:
+#    development:
+#      extractStyles: false
+#    production:
+#      extractStyles: true
 
 
 # Customize Bootstrap variables that get imported before the original Bootstrap variables.

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -25,8 +25,12 @@ const webpackConfig = {
 // ------------------------------------
 // Entry Points
 // ------------------------------------
+
+// In dev, inline Bootstrap styles. In prod, compile them to separate file.
+const bootstrapEntry = __DEV__ ? 'bootstrap-loader' : 'bootstrap-loader/extractStyles';
+
 const APP_ENTRY_PATHS = [
-  'bootstrap-loader',
+  bootstrapEntry,
   'babel-polyfill',
   'whatwg-fetch', // Make fetch() polyfill global.
   paths.client('main.js'),


### PR DESCRIPTION
**What topic does this PR cover?**

Bug fix: 

In production builds, bootstraprc compiled its CSS into the JavaScript bundle, which then dynamically inserted that CSS into the <head> element. This caused it to be loaded after the extracted CSS file, so Bootstrap styles overwrote the equivalent rules in our custom CSS.

In dev, this wasn't an issue because the custom CSS module files are loaded individually in the <head> after the appended Bootstrap CSS. Only because an issue in production because in prod, those files are all concatenated into one.

**Any background context you want to provide?**

Fix was to ensure that in production builds, the Bootstrap CSS is part of the single compiled CSS file (Has the minor added benefit of shifting that CSS out of the JS bundle and into the CSS one, which seems sensible anyway!)